### PR TITLE
remove use of assembly and use solidity, remove unnecessary price history

### DIFF
--- a/src/interfaces/IMedian.sol
+++ b/src/interfaces/IMedian.sol
@@ -52,9 +52,6 @@ interface IMedian {
     // Reads the price and the timestamp
     function read() external view returns (uint256, uint256);
 
-    // Reads historical price data
-    function priceHistory(uint256 index) external view returns (uint256, uint256);
-
     // Reads the currency pair bytes32 value
     function currencyPair() external view returns (bytes32);
 

--- a/test/median.t.sol
+++ b/test/median.t.sol
@@ -87,10 +87,6 @@ contract MedianTest is Test {
         (uint256 lastTimestamp, uint256 lastPrice) = median.read();
         assertEq(lastTimestamp, block.timestamp);
         assertEq(lastPrice, 1e6);
-
-        (uint256 timestamp, uint256 price) = median.priceHistory(0);
-        assertEq(timestamp, block.timestamp);
-        assertEq(price, 1e6);
     }
 
     function test_update_reverts_if_not_minimum_price_source_quorum() external {


### PR DESCRIPTION
- remove use of assembly and use solidity in recover function
- remove unnecessary price history array